### PR TITLE
Potential fix for code scanning alert no. 1: Log entries created from user input

### DIFF
--- a/internal/logger.go
+++ b/internal/logger.go
@@ -11,6 +11,13 @@ import (
 	"time"
 )
 
+// sanitizeForLog ensures user input for log entries cannot inject new log lines
+func sanitizeForLog(s string) string {
+	s = strings.ReplaceAll(s, "\n", "")
+	s = strings.ReplaceAll(s, "\r", "")
+	return s
+}
+
 // LogLevel represents different logging levels
 type LogLevel int
 
@@ -249,7 +256,12 @@ func (sl *SecureLogger) LogHTTPRequest(req *http.Request) {
 		if sl.isSensitiveHeader(name) {
 			sanitizedHeaders[name] = "[REDACTED]"
 		} else {
-			sanitizedHeaders[name] = strings.Join(values, ", ")
+			// Sanitize each header value before joining
+			sanitizedValues := make([]string, len(values))
+			for i, v := range values {
+				sanitizedValues[i] = sanitizeForLog(v)
+			}
+			sanitizedHeaders[name] = strings.Join(sanitizedValues, ", ")
 		}
 	}
 	
@@ -271,7 +283,12 @@ func (sl *SecureLogger) LogHTTPResponse(resp *http.Response) {
 		if sl.isSensitiveHeader(name) {
 			sanitizedHeaders[name] = "[REDACTED]"
 		} else {
-			sanitizedHeaders[name] = strings.Join(values, ", ")
+			// Sanitize each header value before joining
+			sanitizedValues := make([]string, len(values))
+			for i, v := range values {
+				sanitizedValues[i] = sanitizeForLog(v)
+			}
+			sanitizedHeaders[name] = strings.Join(sanitizedValues, ", ")
 		}
 	}
 	


### PR DESCRIPTION
Potential fix for [https://github.com/Zer0C0d3r/TeraFetch/security/code-scanning/1](https://github.com/Zer0C0d3r/TeraFetch/security/code-scanning/1)

To fix the problem, we need to ensure that any user-controlled input that is written to a log entry does not contain line breaks or other characters that could inject/fake a log entry. For this code, the vectors are values written in `sanitizedHeaders` (in `LogHTTPRequest`) and similarly in `LogHTTPResponse`. The best approach is to sanitize each header value before adding it to `sanitizedHeaders`, by removing `\n` and `\r` characters (and optionally others, but line breaks are the minimum required). This can be done with `strings.ReplaceAll`. We should also make a helper function in this file to sanitize such values for log output. This function can be used wherever user-provided data is directly written to the log, specifically for header values in both request and response loggers.

**Required changes:**
- Add a helper method (e.g., `sanitizeForLog`) to remove `\n` and `\r` from strings.
- In both `LogHTTPRequest` and `LogHTTPResponse`, before writing header values to `sanitizedHeaders`, apply this sanitization to each header value.
- Only modify the lines where header value(s) are written into `sanitizedHeaders` in the shown code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
